### PR TITLE
init db

### DIFF
--- a/configs/postgres/initdb.d/init.sql
+++ b/configs/postgres/initdb.d/init.sql
@@ -1,0 +1,74 @@
+-- -- updated_atを入れる関数を作る
+-- CREATE FUNCTION set_updated_at() RETURNS OPAQUE AS `
+--     begin
+--         new.updated_at := ''now'';
+--         return new;
+--     end;
+-- ` LANGUAGE plpgsql;
+
+CREATE FUNCTION set_updated_at() RETURNS OPAQUE AS '
+    begin
+        new.updated_at := ''now'';
+        return new;
+    end;
+' LANGUAGE plpgsql;
+
+CREATE TABLE users
+(
+    id SERIAL NOT NULL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL,
+    profile_img_url VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- 更新時のトリガーを作成
+CREATE TRIGGER update_tri_users BEFORE UPDATE ON users FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+
+CREATE TABLE articles
+(
+    id SERIAL NOT NULL PRIMARY KEY,
+    user_id INT NOT NULL,
+    thumbnail_image_id INT, -- nullable
+    title VARCHAR(100) NOT NULL,
+    body text NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users (id) on DELETE CASCADE
+);
+
+-- 更新時のトリガーを作成
+CREATE TRIGGER update_tri_articles BEFORE UPDATE ON articles FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+
+CREATE TABLE article_images
+(
+    id SERIAL NOT NULL PRIMARY KEY,
+    article_id INT NOT NULL,
+    image_url VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (article_id) REFERENCES articles (id) on DELETE CASCADE
+);
+
+CREATE TRIGGER update_tri_article_images BEFORE UPDATE ON article_images FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+
+CREATE TABLE tags
+(
+    id SERIAL NOT NULL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL UNIQUE,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TRIGGER update_tri_tags BEFORE UPDATE ON tags FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+
+CREATE TABLE article_tags
+(
+    article_id INT NOT NULL,
+    tag_id INT NOT NULL,
+    FOREIGN KEY (article_id) REFERENCES articles (id) on DELETE CASCADE,
+    FOREIGN KEY (tag_id) REFERENCES tags (id) on DELETE CASCADE,
+    PRIMARY KEY(article_id, tag_id)
+);

--- a/configs/postgres/initdb.d/init.sql
+++ b/configs/postgres/initdb.d/init.sql
@@ -1,11 +1,3 @@
--- -- updated_atを入れる関数を作る
--- CREATE FUNCTION set_updated_at() RETURNS OPAQUE AS `
---     begin
---         new.updated_at := ''now'';
---         return new;
---     end;
--- ` LANGUAGE plpgsql;
-
 CREATE FUNCTION set_updated_at() RETURNS OPAQUE AS '
     begin
         new.updated_at := ''now'';
@@ -52,6 +44,7 @@ CREATE TABLE article_images
     FOREIGN KEY (article_id) REFERENCES articles (id) on DELETE CASCADE
 );
 
+-- 更新時のトリガーを作成
 CREATE TRIGGER update_tri_article_images BEFORE UPDATE ON article_images FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
 
 CREATE TABLE tags
@@ -62,6 +55,7 @@ CREATE TABLE tags
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
+-- 更新時のトリガーを作成
 CREATE TRIGGER update_tri_tags BEFORE UPDATE ON tags FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
 
 CREATE TABLE article_tags

--- a/configs/postgres/initdb.d/init.sql
+++ b/configs/postgres/initdb.d/init.sql
@@ -11,7 +11,7 @@ CREATE TABLE users
     name VARCHAR(100) NOT NULL,
     email VARCHAR(255) NOT NULL UNIQUE,
     password VARCHAR(255) NOT NULL,
-    profile_img_url VARCHAR(255) NOT NULL,
+    profile_resource_id VARCHAR(255) NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
@@ -38,7 +38,7 @@ CREATE TABLE article_images
 (
     id SERIAL NOT NULL PRIMARY KEY,
     article_id INT NOT NULL,
-    image_url VARCHAR(255) NOT NULL,
+    resource_id VARCHAR(255) NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (article_id) REFERENCES articles (id) on DELETE CASCADE
@@ -66,3 +66,5 @@ CREATE TABLE article_tags
     FOREIGN KEY (tag_id) REFERENCES tags (id) on DELETE CASCADE,
     PRIMARY KEY(article_id, tag_id)
 );
+
+CREATE INDEX ON article_tags (tag_id);


### PR DESCRIPTION
## ERD
https://drive.google.com/file/d/1TGqFK3qw8rmY8huXjy_gyperxViDhmJq/view?usp=sharing

## table一覧
```
postgres=# \d
                  List of relations
 Schema |         Name          |   Type   |  Owner   
--------+-----------------------+----------+----------
 public | article_images        | table    | postgres
 public | article_images_id_seq | sequence | postgres
 public | article_tags          | table    | postgres
 public | articles              | table    | postgres
 public | articles_id_seq       | sequence | postgres
 public | tags                  | table    | postgres
 public | tags_id_seq           | sequence | postgres
 public | users                 | table    | postgres
 public | users_id_seq          | sequence | postgres
(9 rows)
```

## users table
```
postgres=# \d users;
                                             Table "public.users"
       Column        |            Type             | Collation | Nullable |              Default              
---------------------+-----------------------------+-----------+----------+-----------------------------------
 id                  | integer                     |           | not null | nextval('users_id_seq'::regclass)
 name                | character varying(100)      |           | not null | 
 email               | character varying(255)      |           | not null | 
 password            | character varying(255)      |           | not null | 
 profile_resource_id | character varying(255)      |           | not null | 
 created_at          | timestamp without time zone |           | not null | CURRENT_TIMESTAMP
 updated_at          | timestamp without time zone |           | not null | CURRENT_TIMESTAMP
Indexes:
    "users_pkey" PRIMARY KEY, btree (id)
    "users_email_key" UNIQUE CONSTRAINT, btree (email)
Referenced by:
    TABLE "articles" CONSTRAINT "articles_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
Triggers:
    update_tri_users BEFORE UPDATE ON users FOR EACH ROW EXECUTE FUNCTION set_updated_at()

```

## articles table
```
postgres=# \d articles;
                                            Table "public.articles"
       Column       |            Type             | Collation | Nullable |               Default                
--------------------+-----------------------------+-----------+----------+--------------------------------------
 id                 | integer                     |           | not null | nextval('articles_id_seq'::regclass)
 user_id            | integer                     |           | not null | 
 thumbnail_image_id | integer                     |           |          | 
 title              | character varying(100)      |           | not null | 
 body               | text                        |           | not null | 
 created_at         | timestamp without time zone |           | not null | CURRENT_TIMESTAMP
 updated_at         | timestamp without time zone |           | not null | CURRENT_TIMESTAMP
Indexes:
    "articles_pkey" PRIMARY KEY, btree (id)
Foreign-key constraints:
    "articles_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
Referenced by:
    TABLE "article_images" CONSTRAINT "article_images_article_id_fkey" FOREIGN KEY (article_id) REFERENCES articles(id) ON DELETE CASCADE
    TABLE "article_tags" CONSTRAINT "article_tags_article_id_fkey" FOREIGN KEY (article_id) REFERENCES articles(id) ON DELETE CASCADE
Triggers:
    update_tri_articles BEFORE UPDATE ON articles FOR EACH ROW EXECUTE FUNCTION set_updated_at()

```

## article_images table
```
postgres=# \d article_images;
                                         Table "public.article_images"
   Column    |            Type             | Collation | Nullable |                  Default                   
-------------+-----------------------------+-----------+----------+--------------------------------------------
 id          | integer                     |           | not null | nextval('article_images_id_seq'::regclass)
 article_id  | integer                     |           | not null | 
 resource_id | character varying(255)      |           | not null | 
 created_at  | timestamp without time zone |           | not null | CURRENT_TIMESTAMP
 updated_at  | timestamp without time zone |           | not null | CURRENT_TIMESTAMP
Indexes:
    "article_images_pkey" PRIMARY KEY, btree (id)
Foreign-key constraints:
    "article_images_article_id_fkey" FOREIGN KEY (article_id) REFERENCES articles(id) ON DELETE CASCADE
Triggers:
    update_tri_article_images BEFORE UPDATE ON article_images FOR EACH ROW EXECUTE FUNCTION set_updated_at()

```

## tags table
```
postgres=# \d tags;
                                        Table "public.tags"
   Column   |            Type             | Collation | Nullable |             Default              
------------+-----------------------------+-----------+----------+----------------------------------
 id         | integer                     |           | not null | nextval('tags_id_seq'::regclass)
 name       | character varying(100)      |           | not null | 
 created_at | timestamp without time zone |           | not null | CURRENT_TIMESTAMP
 updated_at | timestamp without time zone |           | not null | CURRENT_TIMESTAMP
Indexes:
    "tags_pkey" PRIMARY KEY, btree (id)
    "tags_name_key" UNIQUE CONSTRAINT, btree (name)
Referenced by:
    TABLE "article_tags" CONSTRAINT "article_tags_tag_id_fkey" FOREIGN KEY (tag_id) REFERENCES tags(id) ON DELETE CASCADE
Triggers:
    update_tri_tags BEFORE UPDATE ON tags FOR EACH ROW EXECUTE FUNCTION set_updated_at()

```

## article_tags table
```
postgres=# \d article_tags;
              Table "public.article_tags"
   Column   |  Type   | Collation | Nullable | Default 
------------+---------+-----------+----------+---------
 article_id | integer |           | not null | 
 tag_id     | integer |           | not null | 
Indexes:
    "article_tags_pkey" PRIMARY KEY, btree (article_id, tag_id)
    "article_tags_tag_id_idx" btree (tag_id)
Foreign-key constraints:
    "article_tags_article_id_fkey" FOREIGN KEY (article_id) REFERENCES articles(id) ON DELETE CASCADE
    "article_tags_tag_id_fkey" FOREIGN KEY (tag_id) REFERENCES tags(id) ON DELETE CASCADE

```