### PR TITLE
画像のinputに同じnameを指定し、ラジオボタンを1つのグループとして扱う

### DIFF
--- a/web/templates/articles/articleCreate.php
+++ b/web/templates/articles/articleCreate.php
@@ -12,11 +12,6 @@
     <?php endforeach; ?>
 </ul>
 <?php endif; ?>
-
-<!-- <input type="radio" name="sex" id="man"><label for="man">男</label>
-<input type="radio" name="sex" id="woman"><label for="woman">女</label>
-<input type="radio" name="sex" id="none"><label for="none">未選択</label> -->
-
 <form action="/articles/create" method="post" enctype="multipart/form-data" name="postForm">
     <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf_token, ENT_QUOTES, "UTF-8") ?>">
     <label class="title" for="title">タイトル</label>

--- a/web/templates/articles/articleCreate.php
+++ b/web/templates/articles/articleCreate.php
@@ -13,7 +13,11 @@
 </ul>
 <?php endif; ?>
 
-<form action="/articles/create" method="post" enctype="multipart/form-data">
+<!-- <input type="radio" name="sex" id="man"><label for="man">男</label>
+<input type="radio" name="sex" id="woman"><label for="woman">女</label>
+<input type="radio" name="sex" id="none"><label for="none">未選択</label> -->
+
+<form action="/articles/create" method="post" enctype="multipart/form-data" name="postForm">
     <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf_token, ENT_QUOTES, "UTF-8") ?>">
     <label class="title" for="title">タイトル</label>
     <input id="title" type="text" name="title" required>
@@ -26,11 +30,13 @@
 <script>
     // 方針
     // 画像のプレビューと共に、サムネイル指定できるradioボタンを表示する
-    // サムネイル指定したらinputにname='is-thumbnail'を付与し、それ以外のinputからはnameを削除する
+    // サムネイル指定したらinputにvalue=filenameを付与し、それ以外のinputからはnameを削除する
 
     let ids = [];
+    let values = [];
+
     // ref: https://code-kitchen.dev/html/input-file/
-    function previewFile(file) {
+    const previewFile = (file) => {
         // プレビュー画像を追加する要素を取得
         const preview = document.getElementById('preview');
 
@@ -41,6 +47,8 @@
             const img = document.createElement("img");
             img.src = imageUrl;
             const filename = file.name;
+            // ここでvaluesにfilenameをpush
+            values.push(filename);
             img.setAttribute('style', 'height:200px; width: 200px;')
             preview.appendChild(img);
             // randomなidを渡す
@@ -50,8 +58,8 @@
             const input = document.createElement("input");
             input.setAttribute("type", 'radio');
             input.setAttribute("id", random);
-            input.setAttribute('value', filename);
-            preview.appendChild(input)
+            input.setAttribute("name", "is-thumbnail");
+            preview.appendChild(input);
             // label要素を作る
             const label = document.createElement('label');
             label.setAttribute('for', random);
@@ -71,26 +79,24 @@
     }
     fileInput.addEventListener('change', handleFileSelect);
 
-    const setNameInSelectedInput = (e) => {
-        // name='is-thumbnail'がついているものを消す
+    const setValueInSelectedInput = (e) => {
         let inputs = [];
         // idに紐づくinput要素を取得
         for (let i = 0; i < ids.length; i++) {
             inputs.push(document.getElementById(ids[i]));
         }
-        // inputsに含まれているnameを削除
+        // e.targetにvalue=filenameを付与する、
+        // それ以外はvalueを消す
         for (let i = 0; i < inputs.length; i++) {
-            if (inputs[i].name == 'is-thumbnail') {
-                inputs[i].removeAttribute('name');
+            if (inputs[i].checked) {
+                e.target.setAttribute('value', values[i]);
+            } else {
+                inputs[i].removeAttribute('value');
             }
-        }
-        // e.targetにname='is-thumbnail'を付与する
-        if (e.target.type == 'radio') {
-            e.target.setAttribute('name', 'is-thumbnail');
         }
     }
 
-    window.addEventListener('change', setNameInSelectedInput);
+    window.addEventListener('change', setValueInSelectedInput);
 </script>
 </body>
 </html>


### PR DESCRIPTION
## 現状

radioボタンに同じ`name`がついていなかったため、別のradioボタンを押しても、前に選択したボタンも選択されっぱなしになる。


https://user-images.githubusercontent.com/42329711/171571945-03045dc2-5e3b-4fef-8650-032c9c2932b2.mov

https://www.tagindex.com/html_tag/form/input_radio.html
> 複数のラジオボタンに同じ部品名を付けることで、1つのグループを作ることができます。ラジオボタンでは、そのグループの中から1つだけを選択することができます。

## 修正後

別のradioボタンを押すと、前に選択したボタンは選択が外れる


https://user-images.githubusercontent.com/42329711/171571668-319c839d-3f9f-414a-99ec-0b2c2c013c97.mov
