### PR TITLE
投稿の編集、更新、削除は他のユーザーは行えない

### DIFF
--- a/web/helpers/UpdateArticleHelper.php
+++ b/web/helpers/UpdateArticleHelper.php
@@ -1,0 +1,29 @@
+<?php
+require_once 'models/Article.php';
+require_once 'models/Tag.php';
+
+class UpdateDeleteArticleHelper
+{
+    static function unauthorized()
+    {
+        return self::setErrorResponse(401);
+    }
+
+    private static function setErrorResponse(int $statusCode): void
+    {
+        http_response_code($statusCode);
+        $_SESSION['ERRORS'] = '他のユーザーの投稿は、編集、更新、削除できません';
+        header("Location: /articles");
+        return;
+    }
+
+    static function hasAuthorization(array $session, int $id): bool
+    {
+        $connection = new Article();
+        // sessionのユーザーと記事投稿したユーザーが一致しなければエラー
+        if ($session['EMAIL'] !== $connection->getUserEmailByArticleID($id)[0]['email']) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/web/models/Article.php
+++ b/web/models/Article.php
@@ -90,6 +90,7 @@ class Article extends BaseModel
         }
 
         try {
+            // TODO: 作る人が固定なのでそれを可変に
             $stmt_articles = $this->db->prepare("INSERT INTO articles (user_id, thumbnail_image_id, title, body) VALUES (1, NULL, :title, :body)");
             $stmt_articles->bindParam(':title', $title);
             $stmt_articles->bindParam(':body', $body);

--- a/web/models/Article.php
+++ b/web/models/Article.php
@@ -2,14 +2,16 @@
 require_once 'models/BaseModel.php';
 require_once 'models/Tag.php';
 
-class Article extends BaseModel {
+class Article extends BaseModel
+{
 
     function __construct()
     {
         parent::__construct();
     }
 
-    public function getAll() {
+    public function getAll()
+    {
         // 同じカラム名(id)がふたつ帰ってくるからasで対応
         $sql = "SELECT
                     articles.id as id,
@@ -30,7 +32,9 @@ class Article extends BaseModel {
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
-    public function getByID(int $id) {
+
+    public function getByID(int $id)
+    {
         $sql = "SELECT
                     articles.id as id,
                     articles.title as title,
@@ -59,7 +63,26 @@ class Article extends BaseModel {
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
-    public function create(string $title, string $body, array $resources, string $thumbnail_resource, array $tags) {
+    public function getUserEmailByArticleID(int $id)
+    {
+        $sql = "SELECT
+                    users.email
+                FROM
+                    articles
+                    INNER JOIN
+                        users
+                    ON articles.user_id = users.id
+                WHERE
+                    articles.id = :id
+                ;";
+        $stmt = $this->db->prepare($sql);
+        $stmt->bindParam(':id', $id);
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function create(string $title, string $body, array $resources, string $thumbnail_resource, array $tags)
+    {
         $this->db->beginTransaction();
 
         if (!$this->db->inTransaction()) {
@@ -119,12 +142,13 @@ class Article extends BaseModel {
 
     // 追加の画像がなかった時
     public function updateExceptImages(
-        int $id,
+        int    $id,
         string $title,
         string $body,
         string $thumbnail_resource,
-        array $tags
-    ) {
+        array  $tags
+    )
+    {
         // tagを更新
         $tag_connection = new Tag();
         $tag_connection->updateArticleTags($id, $tags);
@@ -151,13 +175,14 @@ class Article extends BaseModel {
     }
 
     public function update(
-        int $id,
+        int    $id,
         string $title,
         string $body,
-        array $resources,
+        array  $resources,
         string $thumbnail_resource,
-        array $tags
-    ) {
+        array  $tags
+    )
+    {
         $this->db->beginTransaction();
 
         if (!$this->db->inTransaction()) {
@@ -222,7 +247,8 @@ class Article extends BaseModel {
         }
     }
 
-    public function delete(int $id) {
+    public function delete(int $id)
+    {
         $stmt = $this->db->prepare("DELETE FROM articles WHERE id = :id");
         $stmt->bindParam(':id', $id);
         $stmt->execute();

--- a/web/templates/articles/articles.php
+++ b/web/templates/articles/articles.php
@@ -6,7 +6,14 @@
 </head>
 <body>
 <?php include 'templates/session.php'; ?>
-<?php foreach($articles as $article) : ?>
+
+<?php if(isset($_SESSION['ERRORS'])): ?>
+<ul class="error_list">
+    <li style="color:red"><?= htmlspecialchars($_SESSION['ERRORS'], ENT_QUOTES, "UTF-8") ?></li>
+</ul>
+<?php endif; ?>
+
+<?php foreach ($articles as $article) : ?>
     <h3><?= htmlspecialchars($article['id'], ENT_QUOTES, "UTF-8") ?></h3>
     <img src="../templates/images/<?= htmlspecialchars($article['resource_id'], ENT_QUOTES, "UTF-8") ?>.png" alt="" style="width:200px; height:200px">
     <h3><?= htmlspecialchars($article['title'], ENT_QUOTES, "UTF-8") ?></h3>
@@ -16,7 +23,7 @@
         <button type="submit">Delete</button>
     </form>
     <p>-------------------------</p>
-<?php endforeach;?>
+<?php endforeach; ?>
 <button type="button" onclick="location.href='/articles/create'">新規作成</button>
 </body>
 </html>

--- a/web/views/ArticleController.php
+++ b/web/views/ArticleController.php
@@ -5,6 +5,7 @@ require_once 'models/Tag.php';
 require_once 'helpers/CreateArticleHelper.php';
 require_once 'helpers/Session.php';
 require_once 'helpers/ThumbnailHelper.php';
+require_once 'helpers/UpdateArticleHelper.php';
 require_once 'validations/ArticleValidation.php';
 
 class ArticleController
@@ -25,6 +26,8 @@ class ArticleController
     {
         $session = new Session();
         $csrf_token = $session->create_csrf_token();
+        // ERRORSのsessionを消す
+        unset($_SESSION['ERRORS']);
         $connection = new Article();
         $article = $connection->getByID($id);
         if (count($article) === 0) {
@@ -89,6 +92,19 @@ class ArticleController
         $connection = new Article();
         $article = $connection->getByID($id);
 
+        // ログインチェック
+        // そもそもsetされているか確認
+        if (!isset($_SESSION['EMAIL'])) {
+            return UpdateDeleteArticleHelper::unauthorized();
+        }
+
+        $connection = new Article();
+
+        // sessionのユーザーと記事投稿したユーザーが一致しなければエラー
+        if (!UpdateDeleteArticleHelper::hasAuthorization($_SESSION, $id)) {
+            return UpdateDeleteArticleHelper::unauthorized();
+        }
+
         if (count($article) === 0) {
             http_response_code(404);
             include 'templates/404.php';
@@ -111,7 +127,18 @@ class ArticleController
             return;
         }
 
+        // ログインチェック
+        // そもそもsetされているか確認
+        if (!isset($_SESSION['EMAIL'])) {
+            return UpdateDeleteArticleHelper::unauthorized();
+        }
+
         $connection = new Article();
+        // sessionのユーザーと記事投稿したユーザーが一致しなければエラー
+        if (!UpdateDeleteArticleHelper::hasAuthorization($_SESSION, $id)) {
+            return UpdateDeleteArticleHelper::unauthorized();
+        }
+
         $title = $_POST['title'];
         $body = $_POST['body'];
         $thumbnail_resource = $_POST['is-thumbnail'];
@@ -152,7 +179,19 @@ class ArticleController
         if (!$session->check_csrf_token()) {
             return;
         }
+
+        // ログインチェック
+        // そもそもsetされているか確認
+        if (!isset($_SESSION['EMAIL'])) {
+            return UpdateDeleteArticleHelper::unauthorized();
+        }
+
         $connection = new Article();
+        // sessionのユーザーと記事投稿したユーザーが一致しなければエラー
+        if (!UpdateDeleteArticleHelper::hasAuthorization($_SESSION, $id)) {
+            return UpdateDeleteArticleHelper::unauthorized();
+        }
+
         $connection->delete($id);
         header("Location: /articles");
     }


### PR DESCRIPTION
## 要件
- [x] 投稿の編集、更新、削除は他のユーザーは行えない状態にすること。他人の投稿を編集、更新、削除するためのURLを叩くと、投稿一覧ページに遷移して「他のユーザーの投稿は、編集、更新、削除できません」のエラーメッセージを表示させる。

## 動作検証

https://user-images.githubusercontent.com/42329711/172783836-9409f2af-0b0a-4a87-adc1-fd7ec2620143.mov

この記事を作ったのは違う人です
<img width="428" alt="image" src="https://user-images.githubusercontent.com/42329711/172786283-8bf5aa47-1536-4841-8d95-837a03aa0fbb.png">

